### PR TITLE
Fix resource type casing for advanced workbook

### DIFF
--- a/updateable workbook/Planning Guide for Cloud Roles and Operations Management v0.9a.json
+++ b/updateable workbook/Planning Guide for Cloud Roles and Operations Management v0.9a.json
@@ -12518,7 +12518,7 @@
   "resources": [
     {
       "name": "[parameters('workbookId')]",
-      "type": "microsoft.insights/workbooks",
+      "type": "Microsoft.Insights/workbooks",
       "location": "[resourceGroup().location]",
       "apiVersion": "2021-03-08",
       "dependsOn": [],

--- a/updateable workbook/Planning Guide for Cloud Roles and Operations Management v0.9a.json
+++ b/updateable workbook/Planning Guide for Cloud Roles and Operations Management v0.9a.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "workbookDisplayName": {
@@ -12537,6 +12538,5 @@
       "type": "string",
       "value": "[resourceId( 'microsoft.insights/workbooks', parameters('workbookId'))]"
     }
-  },
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"
+  }
 }

--- a/updateable workbook/Planning Guide for Cloud Roles and Operations Management v0.9a.json
+++ b/updateable workbook/Planning Guide for Cloud Roles and Operations Management v0.9a.json
@@ -12521,9 +12521,9 @@
       "name": "[parameters('workbookId')]",
       "type": "Microsoft.Insights/workbooks",
       "location": "[resourceGroup().location]",
+      "kind": "shared",
       "apiVersion": "2021-03-08",
       "dependsOn": [],
-      "kind": "shared",
       "properties": {
         "displayName": "[parameters('workbookDisplayName')]",
         "serializedData": "[string(variables('workbookContent'))]",


### PR DESCRIPTION
Fixing resource type casing for the advanced workbook. Same as the issue described in #54 and remediated in #55 for the basic workbook